### PR TITLE
feat: host functions from NEP-616

### DIFF
--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -177,6 +177,7 @@ imports! {
     #[deterministic_account_ids] promise_batch_action_state_init<[promise_idx: u64, state_init_len: u64, state_init_ptr: u64, amount_ptr: u64] -> []>,
     #[deterministic_account_ids] promise_result_length<[result_idx: u64] -> [u64]>,
     #[deterministic_account_ids] current_contract_code<[register_id: u64] -> [u64]>,
+    #[deterministic_account_ids] refund_to_account_id<[register_id: u64] -> []>,
     #[deterministic_account_ids] storage_config_byte_cost<[balance_ptr: u64] -> []>,
     #[deterministic_account_ids] storage_config_num_bytes_account<[] -> [u64]>,
     #[deterministic_account_ids] storage_config_num_extra_bytes_record<[] -> [u64]>,

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -176,7 +176,7 @@ imports! {
     #[deterministic_account_ids] promise_set_refund_to<[promise_index: u64, account_id_len: u64, account_id_ptr: u64] -> []>,
     #[deterministic_account_ids] promise_batch_action_state_init<[promise_idx: u64, state_init_len: u64, state_init_ptr: u64, amount_ptr: u64] -> []>,
     #[deterministic_account_ids] promise_result_length<[result_idx: u64] -> [u64]>,
-    #[deterministic_account_ids] current_contract_code<[register_id: u64] -> []>,
+    #[deterministic_account_ids] current_contract_code<[register_id: u64] -> [u64]>,
     #[deterministic_account_ids] storage_config_byte_cost<[balance_ptr: u64] -> []>,
     #[deterministic_account_ids] storage_config_num_bytes_account<[] -> [u64]>,
     #[deterministic_account_ids] storage_config_num_extra_bytes_record<[] -> [u64]>,

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -175,6 +175,11 @@ imports! {
     promise_batch_then<[promise_index: u64, account_id_len: u64, account_id_ptr: u64] -> [u64]>,
     #[deterministic_account_ids] promise_set_refund_to<[promise_index: u64, account_id_len: u64, account_id_ptr: u64] -> []>,
     #[deterministic_account_ids] promise_batch_action_state_init<[promise_idx: u64, state_init_len: u64, state_init_ptr: u64, amount_ptr: u64] -> []>,
+    #[deterministic_account_ids] promise_result_length<[result_idx: u64] -> [u64]>,
+    #[deterministic_account_ids] current_contract_code<[register_id: u64] -> []>,
+    #[deterministic_account_ids] storage_config_byte_cost<[balance_ptr: u64] -> []>,
+    #[deterministic_account_ids] storage_config_num_bytes_account<[] -> [u64]>,
+    #[deterministic_account_ids] storage_config_num_extra_bytes_record<[] -> [u64]>,
     // #######################
     // # Promise API actions #
     // #######################

--- a/runtime/near-vm-runner/src/logic/context.rs
+++ b/runtime/near-vm-runner/src/logic/context.rs
@@ -1,4 +1,5 @@
 use super::types::{PromiseResult, PublicKey};
+use near_primitives_core::account::AccountContract;
 use near_primitives_core::config::ViewConfig;
 use near_primitives_core::types::{
     AccountId, Balance, BlockHeight, EpochHeight, Gas, StorageUsage,
@@ -40,6 +41,8 @@ pub struct VMContext {
     pub account_locked_balance: Balance,
     /// The account's storage usage before the contract execution
     pub storage_usage: StorageUsage,
+    /// The account's current contract code
+    pub account_contract: AccountContract,
     /// The balance that was attached to the call that will be immediately deposited before the
     /// contract execution starts.
     pub attached_deposit: Balance,

--- a/runtime/near-vm-runner/src/logic/context.rs
+++ b/runtime/near-vm-runner/src/logic/context.rs
@@ -21,6 +21,10 @@ pub struct VMContext {
     /// If this execution is the result of direct execution of transaction then it
     /// is equal to `signer_account_id`.
     pub predecessor_account_id: AccountId,
+    /// Where balance refunds after failure should go. Usually the same as
+    /// `predecessor_account_id` but may have been changed by the predecessor
+    /// via host function `promise_set_refund_to`.
+    pub refund_to_account_id: AccountId,
     /// The input to the contract call.
     /// Encoded as base64 string to be able to pass input in borsh binary format.
     pub input: Vec<u8>,

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -727,6 +727,34 @@ impl<'a> VMLogic<'a> {
         )
     }
 
+    /// Saves the account id that was set for the current receipt by its
+    /// predecessor via [`Self::promise_set_refund_to()`], or
+    /// [`Self::predecessor_account_id()`] otherwise, into the register.
+    ///
+    /// # Errors
+    ///
+    /// If the registers exceed the memory limit returns `MemoryAccessViolation`.
+    ///
+    /// # Cost
+    ///
+    /// `base + write_register_base + write_register_byte * num_bytes`
+    pub fn refund_to_account_id(&mut self, register_id: u64) -> Result<()> {
+        self.result_state.gas_counter.pay_base(base)?;
+
+        if self.context.is_view() {
+            return Err(HostError::ProhibitedInView {
+                method_name: "refund_to_account_id".to_string(),
+            }
+            .into());
+        }
+        self.registers.set(
+            &mut self.result_state.gas_counter,
+            &self.config.limit_config,
+            register_id,
+            self.context.refund_to_account_id.as_bytes(),
+        )
+    }
+
     /// Reads input to the contract call into the register. Input is expected to be in JSON-format.
     /// If input is provided saves the bytes (potentially zero) of input into register. If input is
     /// not provided writes 0 bytes into the register.

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -3690,7 +3690,11 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
     pub fn storage_config_byte_cost(&mut self, balance_ptr: u64) -> Result<()> {
         self.result_state.gas_counter.pay_base(base)?;
         let cost_per_byte = self.fees_config.storage_usage_config.storage_amount_per_byte;
-        self.memory.set_u128(&mut self.result_state.gas_counter, balance_ptr, cost_per_byte)
+        self.memory.set_u128(
+            &mut self.result_state.gas_counter,
+            balance_ptr,
+            cost_per_byte.as_yoctonear(),
+        )
     }
 
     /// Returns the protocol storage configuration parameter value for `num_bytes_account`.

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -3098,6 +3098,45 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         Ok(self.context.promise_results.len() as _)
     }
 
+    /// A method to check how much memory [`Self::promise_result()`] would return.
+    ///
+    /// If the current function is invoked by a callback, we can access the length of execution
+    /// results of the promises that caused the callback. It can be used to prevent out-of-gas
+    /// failures when reading too long execution result via [`Self::promise_result()`].
+    ///
+    /// # Returns
+    ///
+    /// * If promise result is complete and successful returns the length in bytes of the promise result;
+    /// * If promise result is not complete or failed returns `0`;
+    ///
+    /// # Errors
+    ///
+    /// * If `result_idx` does not correspond to an existing result returns [`HostError::InvalidPromiseResultIndex`];
+    /// * If called as view function returns [`HostError::ProhibitedInView`].
+    ///
+    /// # Cost
+    ///
+    /// `base` - the base cost for a simple host function call
+    pub fn promise_result_length(&mut self, result_idx: u64) -> Result<u64> {
+        self.result_state.gas_counter.pay_base(base)?;
+        if self.context.is_view() {
+            return Err(HostError::ProhibitedInView {
+                method_name: "promise_result_length".to_string(),
+            }
+            .into());
+        }
+        match self
+            .context
+            .promise_results
+            .get(result_idx as usize)
+            .ok_or(HostError::InvalidPromiseResultIndex { result_idx })?
+        {
+            PromiseResult::Successful(data) => Ok(data.len() as u64),
+            PromiseResult::NotReady => Ok(0),
+            PromiseResult::Failed => Ok(0),
+        }
+    }
+
     /// If the current function is invoked by a callback we can access the execution results of the
     /// promises that caused the callback. This function returns the result in blob format and
     /// places it into the register.
@@ -3350,6 +3389,12 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         self.result_state.checked_push_log(format!("ABORT: {}", message))?;
 
         Err(HostError::GuestPanic { panic_msg: message }.into())
+    }
+
+    pub fn current_contract_code(&mut self, _register_id: u64) -> Result<()> {
+        self.result_state.gas_counter.pay_base(base)?;
+        // TODO(sharded_contracts): implement this host function (done in a separate commit as it is a bit more involved than the other new host functions)
+        todo!()
     }
 
     // ###############
@@ -3633,6 +3678,41 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
 
         self.recorded_storage_counter.observe_size(self.ext.get_recorded_storage_size())?;
         Ok(res? as u64)
+    }
+
+    /// Write the protocol storage configuration parameter value for `storage_amount_per_byte` to
+    /// the location defined by `balance_ptr`.
+    ///
+    /// # Cost
+    ///
+    /// `base` - the base cost for a simple host function call
+    /// `write_memory_base` + 16 * `write_memory_byte` - the cost of writing a `u128` to guest memory
+    pub fn storage_config_byte_cost(&mut self, balance_ptr: u64) -> Result<()> {
+        self.result_state.gas_counter.pay_base(base)?;
+        let cost_per_byte = self.fees_config.storage_usage_config.storage_amount_per_byte;
+        self.memory.set_u128(&mut self.result_state.gas_counter, balance_ptr, cost_per_byte)
+    }
+
+    /// Returns the protocol storage configuration parameter value for `num_bytes_account`.
+    ///
+    /// # Cost
+    ///
+    /// `base` - the base cost for a simple host function call
+    pub fn storage_config_num_bytes_account(&mut self) -> Result<u64> {
+        self.result_state.gas_counter.pay_base(base)?;
+        let bytes = self.fees_config.storage_usage_config.num_bytes_account;
+        Ok(bytes)
+    }
+
+    /// Returns the protocol storage configuration parameter value for `num_extra_bytes_record`.
+    ///
+    /// # Cost
+    ///
+    /// `base` - the base cost for a simple host function call
+    pub fn storage_config_num_extra_bytes_record(&mut self) -> Result<u64> {
+        self.result_state.gas_counter.pay_base(base)?;
+        let bytes = self.fees_config.storage_usage_config.num_extra_bytes_record;
+        Ok(bytes)
     }
 
     /// Debug print given utf-8 string to node log. It's only available in Sandbox node

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -18,6 +18,7 @@ use near_parameters::vm::Config;
 use near_parameters::{
     ActionCosts, ExtCosts, RuntimeFeesConfig, transfer_exec_fee, transfer_send_fee,
 };
+use near_primitives_core::account::AccountContract;
 use near_primitives_core::config::INLINE_DISK_VALUE_THRESHOLD;
 use near_primitives_core::deterministic_account_id::DeterministicAccountStateInit;
 use near_primitives_core::hash::CryptoHash;
@@ -3391,10 +3392,57 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         Err(HostError::GuestPanic { panic_msg: message }.into())
     }
 
-    pub fn current_contract_code(&mut self, _register_id: u64) -> Result<()> {
+    /// Writes the code deployed on current contract being executed to the register.
+    ///
+    /// The output data in the register will either be empty, `CryptoHash`, or `AccountId`,
+    /// depending on the return value.
+    ///
+    /// # Returns
+    ///
+    /// Returns a different number depending on the type of contract that is stored on the account
+    ///  (and has been written to the register).
+    ///
+    /// * 0 if the contract code is None
+    /// * 1 if the contract code is Local(CryptoHash)
+    /// * 2 if the contract code is Global(CryptoHash)
+    /// * 3 if the contract code is GlobalByAccount(AccountId)
+    ///
+    /// # Cost
+    ///
+    /// `base` - the base cost for a simple host function call `write_memory_base` + 16 *
+    /// `write_memory_byte` - the cost of writing the data to the register
+    pub fn current_contract_code(&mut self, register_id: u64) -> Result<u64> {
         self.result_state.gas_counter.pay_base(base)?;
-        // TODO(sharded_contracts): implement this host function (done in a separate commit as it is a bit more involved than the other new host functions)
-        todo!()
+        match &self.context.account_contract {
+            AccountContract::None => Ok(0),
+            AccountContract::Local(crypto_hash) => {
+                self.registers.set(
+                    &mut self.result_state.gas_counter,
+                    &self.config.limit_config,
+                    register_id,
+                    crypto_hash.0,
+                )?;
+                Ok(1)
+            }
+            AccountContract::Global(crypto_hash) => {
+                self.registers.set(
+                    &mut self.result_state.gas_counter,
+                    &self.config.limit_config,
+                    register_id,
+                    crypto_hash.0,
+                )?;
+                Ok(2)
+            }
+            AccountContract::GlobalByAccount(account_id) => {
+                self.registers.set(
+                    &mut self.result_state.gas_counter,
+                    &self.config.limit_config,
+                    register_id,
+                    account_id.as_bytes(),
+                )?;
+                Ok(3)
+            }
+        }
     }
 
     // ###############

--- a/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
@@ -79,6 +79,7 @@ fn get_context() -> VMContext {
         account_balance: Balance::from_yoctonear(100),
         storage_usage: 0,
         account_locked_balance: Balance::from_yoctonear(50),
+        account_contract: near_primitives_core::account::AccountContract::None,
         attached_deposit: Balance::from_yoctonear(10),
         prepaid_gas: Gas::from_teragas(100),
         random_seed: vec![0, 1, 2],

--- a/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
@@ -71,6 +71,7 @@ fn get_context() -> VMContext {
         signer_account_id: "bob.near".parse().unwrap(),
         signer_account_pk: vec![0, 1, 2, 3, 4],
         predecessor_account_id: "carol.near".parse().unwrap(),
+        refund_to_account_id: "david.near".parse().unwrap(),
         input: vec![0, 1, 2, 3, 4],
         promise_results: vec![].into(),
         block_height: 10,

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -57,6 +57,7 @@ fn create_context(input: Vec<u8>) -> VMContext {
         account_balance: Balance::from_yoctonear(2),
         account_locked_balance: Balance::ZERO,
         storage_usage: 12,
+        account_contract: near_primitives_core::account::AccountContract::None,
         attached_deposit: Balance::from_yoctonear(2),
         prepaid_gas: Gas::from_teragas(100),
         random_seed: vec![0, 1, 2],

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -19,6 +19,7 @@ const CURRENT_ACCOUNT_ID: &str = "alice";
 const SIGNER_ACCOUNT_ID: &str = "bob";
 const SIGNER_ACCOUNT_PK: [u8; 3] = [0, 1, 2];
 const PREDECESSOR_ACCOUNT_ID: &str = "carol";
+const REFUND_TO_ACCOUNT_ID: &str = "david";
 
 pub(crate) fn test_vm_config(vm_kind: Option<VMKind>) -> near_parameters::vm::Config {
     let store = RuntimeConfigStore::test();
@@ -49,6 +50,7 @@ fn create_context(input: Vec<u8>) -> VMContext {
         signer_account_id: SIGNER_ACCOUNT_ID.parse().unwrap(),
         signer_account_pk: Vec::from(&SIGNER_ACCOUNT_PK[..]),
         predecessor_account_id: PREDECESSOR_ACCOUNT_ID.parse().unwrap(),
+        refund_to_account_id: REFUND_TO_ACCOUNT_ID.parse().unwrap(),
         input,
         promise_results: Vec::new().into(),
         block_height: 10,

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -53,6 +53,7 @@ pub fn create_context(input: Vec<u8>) -> VMContext {
         account_balance: Balance::from_yoctonear(2),
         account_locked_balance: Balance::ZERO,
         storage_usage: 12,
+        account_contract: near_primitives_core::account::AccountContract::None,
         attached_deposit: Balance::from_yoctonear(2),
         prepaid_gas: near_primitives_core::types::Gas::from_teragas(100),
         random_seed: vec![0, 1, 2],

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -45,6 +45,7 @@ pub fn create_context(input: Vec<u8>) -> VMContext {
         signer_account_id: "bob".parse().unwrap(),
         signer_account_pk: vec![0, 1, 2, 3, 4],
         predecessor_account_id: "carol".parse().unwrap(),
+        refund_to_account_id: "david".parse().unwrap(),
         input,
         promise_results: Vec::new().into(),
         block_height: 10,

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -23,6 +23,7 @@ pub(crate) fn test_builder() -> TestBuilder {
         account_balance: Balance::from_yoctonear(2),
         account_locked_balance: Balance::ZERO,
         storage_usage: 12,
+        account_contract: near_primitives_core::account::AccountContract::None,
         attached_deposit: Balance::from_yoctonear(2),
         prepaid_gas: Gas::from_teragas(100),
         random_seed: vec![0, 1, 2],

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -15,6 +15,7 @@ pub(crate) fn test_builder() -> TestBuilder {
         signer_account_id: "bob".parse().unwrap(),
         signer_account_pk: vec![0, 1, 2],
         predecessor_account_id: "carol".parse().unwrap(),
+        refund_to_account_id: "david".parse().unwrap(),
         input: Vec::new(),
         promise_results: Vec::new().into(),
         block_height: 10,

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -17,6 +17,7 @@ use near_crypto::Secp256K1Signature;
 use near_parameters::{
     ActionCosts, ExtCosts, RuntimeFeesConfig, transfer_exec_fee, transfer_send_fee,
 };
+use near_primitives_core::account::AccountContract;
 use near_primitives_core::config::INLINE_DISK_VALUE_THRESHOLD;
 use near_primitives_core::deterministic_account_id::DeterministicAccountStateInit;
 use near_primitives_core::hash::CryptoHash;
@@ -2699,30 +2700,6 @@ pub fn promise_batch_action_state_init(
     Ok(())
 }
 
-// TODO(sharded_contracts): copy-paste the final implementation of the host
-// functions and adjust to wasmtime runner
-
-pub fn promise_result_length(_caller: &mut Caller<'_, Ctx>, _result_idx: u64) -> Result<u64> {
-    // TODO(sharded_contracts)
-    todo!()
-}
-pub fn current_contract_code(_caller: &mut Caller<'_, Ctx>, _register_id: u64) -> Result<u64> {
-    // TODO(sharded_contracts)
-    todo!()
-}
-pub fn storage_config_byte_cost(_caller: &mut Caller<'_, Ctx>, _balance_ptr: u64) -> Result<()> {
-    // TODO(sharded_contracts)
-    todo!()
-}
-pub fn storage_config_num_bytes_account(_caller: &mut Caller<'_, Ctx>) -> Result<u64> {
-    // TODO(sharded_contracts)
-    todo!()
-}
-pub fn storage_config_num_extra_bytes_record(_caller: &mut Caller<'_, Ctx>) -> Result<u64> {
-    // TODO(sharded_contracts)
-    todo!()
-}
-
 /// Appends `FunctionCall` action to the batch of actions for the given promise pointed by
 /// `promise_idx`.
 ///
@@ -3457,6 +3434,46 @@ pub fn promise_results_count(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
     Ok(ctx.context.promise_results.len() as _)
 }
 
+/// A method to check how much memory [`Self::promise_result()`] would return.
+///
+/// If the current function is invoked by a callback, we can access the length of execution
+/// results of the promises that caused the callback. It can be used to prevent out-of-gas
+/// failures when reading too long execution result via [`Self::promise_result()`].
+///
+/// # Returns
+///
+/// * If promise result is complete and successful returns the length in bytes of the promise result;
+/// * If promise result is not complete or failed returns `0`;
+///
+/// # Errors
+///
+/// * If `result_idx` does not correspond to an existing result returns [`HostError::InvalidPromiseResultIndex`];
+/// * If called as view function returns [`HostError::ProhibitedInView`].
+///
+/// # Cost
+///
+/// `base` - the base cost for a simple host function call
+pub fn promise_result_length(caller: &mut Caller<'_, Ctx>, result_idx: u64) -> Result<u64> {
+    let ctx = caller.data_mut();
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_result_length".to_string(),
+        }
+        .into());
+    }
+    match ctx
+        .context
+        .promise_results
+        .get(result_idx as usize)
+        .ok_or(HostError::InvalidPromiseResultIndex { result_idx })?
+    {
+        PromiseResult::Successful(data) => Ok(data.len() as u64),
+        PromiseResult::NotReady => Ok(0),
+        PromiseResult::Failed => Ok(0),
+    }
+}
+
 /// If the current function is invoked by a callback we can access the execution results of the
 /// promises that caused the callback. This function returns the result in blob format and
 /// places it into the register.
@@ -3739,6 +3756,60 @@ pub fn abort(
     ctx.result_state.checked_push_log(format!("ABORT: {}", message))?;
 
     Err(HostError::GuestPanic { panic_msg: message }.into())
+}
+
+/// Writes the code deployed on current contract being executed to the register.
+///
+/// The output data in the register will either be empty, `CryptoHash`, or `AccountId`,
+/// depending on the return value.
+///
+/// # Returns
+///
+/// Returns a different number depending on the type of contract that is stored on the account
+///  (and has been written to the register).
+///
+/// * 0 if the contract code is None
+/// * 1 if the contract code is Local(CryptoHash)
+/// * 2 if the contract code is Global(CryptoHash)
+/// * 3 if the contract code is GlobalByAccount(AccountId)
+///
+/// # Cost
+///
+/// `base` - the base cost for a simple host function call `write_memory_base` + 16 *
+/// `write_memory_byte` - the cost of writing the data to the register
+pub fn current_contract_code(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<u64> {
+    let ctx = caller.data_mut();
+    ctx.result_state.gas_counter.pay_base(base)?;
+    match &ctx.context.account_contract {
+        AccountContract::None => Ok(0),
+        AccountContract::Local(crypto_hash) => {
+            ctx.registers.set(
+                &mut ctx.result_state.gas_counter,
+                &ctx.config.limit_config,
+                register_id,
+                crypto_hash.0,
+            )?;
+            Ok(1)
+        }
+        AccountContract::Global(crypto_hash) => {
+            ctx.registers.set(
+                &mut ctx.result_state.gas_counter,
+                &ctx.config.limit_config,
+                register_id,
+                crypto_hash.0,
+            )?;
+            Ok(2)
+        }
+        AccountContract::GlobalByAccount(account_id) => {
+            ctx.registers.set(
+                &mut ctx.result_state.gas_counter,
+                &ctx.config.limit_config,
+                register_id,
+                account_id.as_bytes(),
+            )?;
+            Ok(3)
+        }
+    }
 }
 
 // ###############
@@ -4070,6 +4141,45 @@ pub fn storage_has_key(caller: &mut Caller<'_, Ctx>, key_len: u64, key_ptr: u64)
 
     ctx.recorded_storage_counter.observe_size(ctx.ext.get_recorded_storage_size())?;
     Ok(res? as u64)
+}
+
+/// Write the protocol storage configuration parameter value for `storage_amount_per_byte` to
+/// the location defined by `balance_ptr`.
+///
+/// # Cost
+///
+/// `base` - the base cost for a simple host function call
+/// `write_memory_base` + 16 * `write_memory_byte` - the cost of writing a `u128` to guest memory
+pub fn storage_config_byte_cost(caller: &mut Caller<'_, Ctx>, balance_ptr: u64) -> Result<()> {
+    let memory = get_memory(caller)?;
+    let (memory, ctx) = memory.data_and_store_mut(caller);
+    ctx.result_state.gas_counter.pay_base(base)?;
+    let cost_per_byte = ctx.fees_config.storage_usage_config.storage_amount_per_byte;
+    set_u128(&mut ctx.result_state.gas_counter, memory, balance_ptr, cost_per_byte.as_yoctonear())
+}
+
+/// Returns the protocol storage configuration parameter value for `num_bytes_account`.
+///
+/// # Cost
+///
+/// `base` - the base cost for a simple host function call
+pub fn storage_config_num_bytes_account(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
+    let ctx = caller.data_mut();
+    ctx.result_state.gas_counter.pay_base(base)?;
+    let bytes = ctx.fees_config.storage_usage_config.num_bytes_account;
+    Ok(bytes)
+}
+
+/// Returns the protocol storage configuration parameter value for `num_extra_bytes_record`.
+///
+/// # Cost
+///
+/// `base` - the base cost for a simple host function call
+pub fn storage_config_num_extra_bytes_record(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
+    let ctx = caller.data_mut();
+    ctx.result_state.gas_counter.pay_base(base)?;
+    let bytes = ctx.fees_config.storage_usage_config.num_extra_bytes_record;
+    Ok(bytes)
 }
 
 /// Debug print given utf-8 string to node log. It's only available in Sandbox node

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -656,6 +656,35 @@ pub fn predecessor_account_id(caller: &mut Caller<'_, Ctx>, register_id: u64) ->
     )
 }
 
+/// Saves the account id that was set for the current receipt by its
+/// predecessor via [`Self::promise_set_refund_to()`], or
+/// [`Self::predecessor_account_id()`] otherwise, into the register.
+///
+/// # Errors
+///
+/// If the registers exceed the memory limit returns `MemoryAccessViolation`.
+///
+/// # Cost
+///
+/// `base + write_register_base + write_register_byte * num_bytes`
+pub fn refund_to_account_id(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<()> {
+    let ctx = caller.data_mut();
+    ctx.result_state.gas_counter.pay_base(base)?;
+
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "refund_to_account_id".to_string(),
+        }
+        .into());
+    }
+    ctx.registers.set(
+        &mut ctx.result_state.gas_counter,
+        &ctx.config.limit_config,
+        register_id,
+        ctx.context.refund_to_account_id.as_bytes(),
+    )
+}
+
 /// Reads input to the contract call into the register. Input is expected to be in JSON-format.
 /// If input is provided saves the bytes (potentially zero) of input into register. If input is
 /// not provided writes 0 bytes into the register.

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -2670,6 +2670,30 @@ pub fn promise_batch_action_state_init(
     Ok(())
 }
 
+// TODO(sharded_contracts): copy-paste the final implementation of the host
+// functions and adjust to wasmtime runner
+
+pub fn promise_result_length(_caller: &mut Caller<'_, Ctx>, _result_idx: u64) -> Result<u64> {
+    // TODO(sharded_contracts)
+    todo!()
+}
+pub fn current_contract_code(_caller: &mut Caller<'_, Ctx>, _register_id: u64) -> Result<()> {
+    // TODO(sharded_contracts)
+    todo!()
+}
+pub fn storage_config_byte_cost(_caller: &mut Caller<'_, Ctx>, _balance_ptr: u64) -> Result<()> {
+    // TODO(sharded_contracts)
+    todo!()
+}
+pub fn storage_config_num_bytes_account(_caller: &mut Caller<'_, Ctx>) -> Result<u64> {
+    // TODO(sharded_contracts)
+    todo!()
+}
+pub fn storage_config_num_extra_bytes_record(_caller: &mut Caller<'_, Ctx>) -> Result<u64> {
+    // TODO(sharded_contracts)
+    todo!()
+}
+
 /// Appends `FunctionCall` action to the batch of actions for the given promise pointed by
 /// `promise_idx`.
 ///

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -2677,7 +2677,7 @@ pub fn promise_result_length(_caller: &mut Caller<'_, Ctx>, _result_idx: u64) ->
     // TODO(sharded_contracts)
     todo!()
 }
-pub fn current_contract_code(_caller: &mut Caller<'_, Ctx>, _register_id: u64) -> Result<()> {
+pub fn current_contract_code(_caller: &mut Caller<'_, Ctx>, _register_id: u64) -> Result<u64> {
     // TODO(sharded_contracts)
     todo!()
 }

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -30,6 +30,7 @@ pub(crate) fn create_context(input: Vec<u8>) -> VMContext {
         account_balance: Balance::from_yoctonear(2),
         account_locked_balance: Balance::from_yoctonear(1),
         storage_usage: 12,
+        account_contract: near_primitives::account::AccountContract::None,
         attached_deposit: Balance::from_yoctonear(2),
         prepaid_gas: Gas::from_teragas(1_000_000),
         random_seed: vec![0, 1, 2],

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -15,6 +15,7 @@ const CURRENT_ACCOUNT_ID: &str = "alice";
 const SIGNER_ACCOUNT_ID: &str = "bob";
 const SIGNER_ACCOUNT_PK: [u8; 3] = [0, 1, 2];
 const PREDECESSOR_ACCOUNT_ID: &str = "carol";
+const REFUND_TO_ACCOUNT_ID: &str = "carol";
 
 pub(crate) fn create_context(input: Vec<u8>) -> VMContext {
     VMContext {
@@ -22,6 +23,7 @@ pub(crate) fn create_context(input: Vec<u8>) -> VMContext {
         signer_account_id: SIGNER_ACCOUNT_ID.parse().unwrap(),
         signer_account_pk: Vec::from(&SIGNER_ACCOUNT_PK[..]),
         predecessor_account_id: PREDECESSOR_ACCOUNT_ID.parse().unwrap(),
+        refund_to_account_id: REFUND_TO_ACCOUNT_ID.parse().unwrap(),
         input,
         promise_results: vec![].into(),
         block_height: 10,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -73,6 +73,7 @@ pub(crate) fn execute_function_call(
         signer_account_pk: borsh::to_vec(&action_receipt.signer_public_key())
             .expect("Failed to serialize"),
         predecessor_account_id: predecessor_id.clone(),
+        refund_to_account_id: action_receipt.refund_to().as_ref().unwrap_or(predecessor_id).clone(),
         input: function_call.args.clone(),
         promise_results,
         block_height: apply_state.block_height,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -81,6 +81,7 @@ pub(crate) fn execute_function_call(
         account_balance: runtime_ext.account().amount(),
         account_locked_balance: runtime_ext.account().locked(),
         storage_usage: runtime_ext.account().storage_usage(),
+        account_contract: runtime_ext.account().contract().into_owned(),
         attached_deposit: function_call.deposit,
         prepaid_gas: function_call.gas,
         random_seed,


### PR DESCRIPTION
Add a bunch of new supporting host functions.

- current_contract_code
- promise_result_length
- refund_to_account_id
- storage_config_byte_cost
- storage_config_num_bytes_account
- storage_config_num_extra_bytes_record

All of these are to support the main feature or NEP-616 and described in the
same proposal.